### PR TITLE
Added support for passReqToCallback option

### DIFF
--- a/pocket-strategy.js
+++ b/pocket-strategy.js
@@ -72,6 +72,8 @@ function Strategy(options, verify) {
     options.requestTokenURL  = options.requestTokenURL || 'https://getpocket.com/v3/oauth/request';
     options.authorizationURL = options.userAuthorizationURL || 'https://getpocket.com/v3/oauth/authorize';
     options.sessionKey       = options.sessionKey || 'oauth:pocket';
+    options.passReqToCallback = options.passReqToCallback || false;
+
 
     // Api urls
     options.retrive = 'https://getpocket.com/v3/get';
@@ -114,7 +116,12 @@ Strategy.prototype.authenticate = function(req, options) {
                     accessToken : accessToken
                 }
 
-                self._verity(username, accessToken, verified);
+                if (self._options.passReqToCallback){
+                    self._verity(req, username, accessToken, verified);
+                }
+                else{
+                    self._verity(username, accessToken, verified);                    
+                }
             });
         }
     }else{


### PR DESCRIPTION
Added support for passReqToCallback to allow for access to the request object when authentication occurs and to be consistent with the functionality of other core passport strategies.
